### PR TITLE
Add setuptools_scm to conda build requirements

### DIFF
--- a/cond_package/borgbackup/meta.yaml
+++ b/cond_package/borgbackup/meta.yaml
@@ -30,6 +30,7 @@ requirements:
   build:
     - python
     - setuptools
+    - setuptools_scm
     - msgpack-python >=0.4.6
 
   run:


### PR DESCRIPTION
I needed this before the build worked.